### PR TITLE
Use Origami Image Set Tools for publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,16 @@
+
+machine:
+  node:
+    version: 6
+
+deployment:
+  publish-imageset:
+    tag: /v.*/
+    owner: Financial-Times
+    commands:
+      - ./node_modules/.bin/oist publish-s3 --bucket origami-imageset-data-eu --scheme ftpodcast --scheme-version $CIRCLE_TAG
+      - ./node_modules/.bin/oist publish-s3 --bucket origami-imageset-data-us --scheme ftpodcast --scheme-version $CIRCLE_TAG
+
+test:
+  override:
+    - echo "no tests"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "headshot-images",
+  "private": true,
+  "engines": {
+    "node": "^6"
+  },
+  "devDependencies": {
+    "@financial-times/origami-image-set-tools": "^1.0.0"
+  }
+}


### PR DESCRIPTION
Turns out I _do_ need to add some stuff to this repo for publishing, otherwise we'd inadvertently break any podcast images being served by the Image Service.

This doesn't have an `origami.json` or update the manifest though, so it won't appear in the registry.