### PR TITLE
Deprecate

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -4,7 +4,7 @@
 	"origamiVersion": 1,
 	"keywords": [],
 	"support": "https://github.com/Financial-Times/podcast-logos/issues",
-	"supportStatus": "active",
+	"supportStatus": "deprecated",
 	"supportContact": {
 		"email": "origami.support@ft.com",
 		"slack": "financialtimes/ft-origami"

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,7 @@
 #Podcast logos
 
+### This component is deprecated. If you need any podcast images please refer to Acast, the podcast hosting system we use.
+
+***
+
 A set of PNG icons for use with FT podcasts, up to the 1400x1400px size required by Apple's iTunes specification.


### PR DESCRIPTION
- current podcast images are managed via Acast
- images in this image-set have not been served for 90 days

Also thinking we add a description to the repo, something along the lines of:

> This component is deprecated. If you need any podcast images please refer to Acast, the podcast hosting system we use.